### PR TITLE
Update the deprecated search option

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -53,7 +53,8 @@ theme = "relearn"
   # If the search is disabled, no search box will be displayed in the menu,
   # nor in-page search, search popup or dedicated search page will be available.
   # This will also cause the keyboard shortcut to be disabled.
-  disableSearch = false
+  [params.search]
+    disable = false
 
   # Hide the Home entry.
   # Default: false


### PR DESCRIPTION
This changed in relearn 8 to add more search options (which are not currently used). See

https://mcshelby.github.io/hugo-theme-relearn/configuration/sidebar/search/index.html#migration-from-relearn-7